### PR TITLE
fix global object reference for node

### DIFF
--- a/techs/i18n.js
+++ b/techs/i18n.js
@@ -106,7 +106,7 @@ module.exports = buildFlow.create()
                         '        (global.BEM || (global.BEM = {})).I18N = __i18n__;',
                         '    }'
                     ] : '',
-                    '})(this);'
+                    '})(typeof window !== "undefined" ? window : global);'
                 ).join(EOL);
             }, this);
     })


### PR DESCRIPTION
In global scope ```this``` is reference to ```module.exports``` not to ```global```